### PR TITLE
Fixed according to codestyle

### DIFF
--- a/steps/memory-usage/content.md
+++ b/steps/memory-usage/content.md
@@ -252,7 +252,7 @@ end
 puts "Winnie the Pooh is trying to fall asleep..."
 
 # вызвали метод, внутри которого посчитали 5 млн. горшочков
-count_honeypots()
+count_honeypots
 
 # задержка, чтобы успеть увидеть изменение памяти в диспетчере задач
 sleep 3


### PR DESCRIPTION
Если у метода нет параметров, то его вызов без скобок - более true