### PR TITLE
Fix: link to true page(blog)

### DIFF
--- a/steps/if-variables/links.json
+++ b/steps/if-variables/links.json
@@ -6,7 +6,7 @@
     },
     {
       "title": "Чем отличается оператор and и \u0026\u0026 (2)",
-      "url": "http://devblog.avdi.org/2010/08/02/using-and-and-or-in-ruby/"
+      "url": "https://avdi.codes/using-and-and-or-in-ruby/"
     },
     {
       "title": "Чем отличается оператор and и \u0026\u0026 (1)",


### PR DESCRIPTION
# Fix: link to true page(blog)

- wrong: `http://devblog.avdi.org/2010/08/02/using-and-and-or-in-ruby/`
- [x] [Чем отличается оператор and и && (2)](https://avdi.codes/using-and-and-or-in-ruby/)