### PR TITLE
Update methods.rb

### DIFF
--- a/steps/regexp/files/methods.rb
+++ b/steps/regexp/files/methods.rb
@@ -5,13 +5,13 @@ require 'net/http'
 # Метод, word_exits? проверяет, есть ли статья на Викисловаре с таким словом
 def word_exists?(word)
   # Формируем адрес страницы для проверки и записываем в переменную url.
-  url = "https://ru.wiktionary.org/wiki/#{word}"
+  uri = "https://ru.wiktionary.org/wiki/" + URI.encode_www_form_component(word) 
 
   # Достаем содержимое страницы по указанному адресу и записываем в переменную
   # wiktionary_page. Обратите внимание, что мы меняем кодировку на utf-8, чтобы
   # мы могли корректно работать с русскими буквами.
   wiktionary_page = Net::HTTP.get(
-    URI.parse(URI.encode(url))
+    URI(uri)
   ).force_encoding('UTF-8')
 
   # С помощью регулярного выражения проверяем, есть ли на странице текст о том,


### PR DESCRIPTION
URI.encode  works unexpectedly with >= 2.7.0    From official docs: "This method is obsolete and should not be used. Instead, use CGI.escape, URI.encode_www_form or URI.encode_www_form_component depending on your specific use case." Аny of these methods will replace slash with codes
Thus, we could only use these methods with word. Another way could be using HTTP::new directly with domain, but example i selected from "https://ruby-doc.org/stdlib-2.6.5/libdoc/net/http/rdoc/Net/HTTP.html#method-c-get" generates error: "Failed to open TCP connection".. mb the protocol was not specified.. i didn't know why i am newbie
Using method parse is optional cause this method is default for every URI(uri) call. You can look inside /lib/ruby/2.7.0/uri/common.rb => from line 733 onwards